### PR TITLE
lnm: Fix typo in count-variations

### DIFF
--- a/benchmarks/lnm/typed/lnm-plot.rkt
+++ b/benchmarks/lnm/typed/lnm-plot.rkt
@@ -120,7 +120,7 @@
   (define cache (and lim (cache-init sm lim #:L L)))
   (lambda ([N-raw : Real])
     (: N Nonnegative-Real)
-    (define N (if (>= N 0) N (error 'count-variations)))
+    (define N (if (>= N-raw 0) N-raw (error 'count-variations)))
     (: good? (-> String Boolean))
     (define good? (make-variation->good? sm (* N baseline) #:L L))
     (if (and cache lim (<= N lim))

--- a/benchmarks/lnm/untyped/lnm-plot.rkt
+++ b/benchmarks/lnm/untyped/lnm-plot.rkt
@@ -108,7 +108,7 @@
   (define cache (and lim (cache-init sm lim #:L L)))
   (lambda (N)
     (define good? (make-variation->good? sm (* N baseline) #:L L))
-    (if (and cache (<= N lim))
+    (if (and cache lim (<= N lim))
         ;; Use cache to save some work, only test the variations
         ;; in the next bucket
         (cache-lookup cache N good?)


### PR DESCRIPTION
This is a rather pernicious typo. Line 123 in the typed version is introduced to satisfy the typechecker (as the use of `N` in `cache-lookup` has to be a non-negative real). The definition used `N` instead of `N-raw` which should have resulted in a reference before definition error.

However, the plot library makes the dubious decision to silence errors that occur in the function you provide to `function` so this problem went undetected. This means that the code after this line is not executed in configurations with a typed `lnm-plot`, possibly affecting the validity of the current lnm benchmark results.