### PR TITLE
zordoz: Remove unused format call

### DIFF
--- a/benchmarks/zordoz/typed/zo-find.rkt
+++ b/benchmarks/zordoz/typed/zo-find.rkt
@@ -61,7 +61,6 @@
 (: zo-find-aux (-> zo (Listof zo) String Natural (U Natural #f) (Listof result)))
 (define (zo-find-aux z hist str i lim)
   (define-values (title children) (parse-zo z))
-  (define zstr (format "~a" z))
   (: results (Listof result))
   (define results
     (cond


### PR DESCRIPTION
This call to `format` does not appear in the untyped version of the module.