### PR TITLE
V7.0

### DIFF
--- a/benchmarks/lnm/untyped/modulegraph.rkt
+++ b/benchmarks/lnm/untyped/modulegraph.rkt
@@ -93,7 +93,7 @@
          (parse-error "Input is not a TiKZ picture")]
         [(string=? "\\begin{tikzpicture}" (string-trim line))
          ;; Success! We have id'd this file as a TiKZ picture
-         port]
+         (void)]
         [else
          ;; Try again with what's left
          (ensure-tikz port)]))


### PR DESCRIPTION
Fix a bad return value in untyped `lnm`. Before = port, after = void.