### PR TITLE
take5: use players supplied to the dealer instead of making new ones

### DIFF
--- a/benchmarks/take5/typed/dealer.rkt
+++ b/benchmarks/take5/typed/dealer.rkt
@@ -66,10 +66,20 @@
 
     (field
      [internal% : Internal%
-      (class player%
+      (class object%
+        (super-new)
         (init-field player)
-        (super-new [n (send player name)] [order default-order])
-        (field [my-bulls 0])
+        (field [my-bulls 0]
+
+               ;; dummy fields, never used, only here to satisfy the interface
+               [n 0]
+               [order default-order]
+               [my-cards empty])
+        (define/public (name) (send player name))
+        (define/public (start-round cs) (send player start-round cs))
+        (define/public (start-turn d) (send player start-turn d))
+        (define/public (choose d) (send player choose d))
+
         (define/public (bulls) (get-field my-bulls this))
         (define/public (add-score n)
           (set-field! my-bulls this (+ n (get-field my-bulls this)))))]

--- a/benchmarks/take5/untyped/dealer.rkt
+++ b/benchmarks/take5/untyped/dealer.rkt
@@ -56,10 +56,20 @@
 
     (field
      [internal%
-      (class player%
+      (class object%
+        (super-new)
         (init-field player)
-        (super-new [n (send player name)] [order default-order])
-        (field [my-bulls 0])
+        (field [my-bulls 0]
+
+               ;; dummy fields, never used, only here to satisfy the interface
+               [n 0]
+               [order default-order]
+               [my-cards empty])
+        (define/public (name) n)
+        (define/public (start-round cs) (send player start-round cs))
+        (define/public (start-turn d) (send player start-turn d))
+        (define/public (choose d) (send player choose d))
+
         (define/public (bulls) (get-field my-bulls this))
         (define/public (add-score n)
           (set-field! my-bulls this (+ n (get-field my-bulls this)))))]


### PR DESCRIPTION
A possible change to address #37.
It's minimally invasive in the sense of not changing the `Internal%` type, which at least for my current purposes is better than `Internal%` syntactically duplicating player method types.